### PR TITLE
Add emergency shutdown and expand BDI framework

### DIFF
--- a/aethermind/__init__.py
+++ b/aethermind/__init__.py
@@ -1,0 +1,17 @@
+"""AetherMind core cognitive package."""
+
+from .brain import Brain
+from .goals import GoalManager, Goal, Belief
+from .reasoning import ReasoningLoop
+from .safeguard import SelfModificationGuard, EmergencyShutdown
+
+__all__ = [
+    'Brain',
+    'GoalManager',
+    'Goal',
+    'Belief',
+    'ReasoningLoop',
+    'SelfModificationGuard',
+    'EmergencyShutdown',
+]
+

--- a/aethermind/goals.py
+++ b/aethermind/goals.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Belief:
+    """Simple belief representation used by the planner."""
+    statement: str
+    truth: bool = True
+
+@dataclass
+class Goal:
+    """Represents a high-level desire or objective."""
+    description: str
+    priority: int = 0
+    satisfied: bool = False
+
+class GoalManager:
+    """Manages goals, beliefs, and intentions using a BDI-style approach."""
+
+    def __init__(self):
+        self.goals: List[Goal] = []
+        self.beliefs: List[Belief] = []
+
+    def add_goal(self, description: str, priority: int = 0) -> Goal:
+        goal = Goal(description=description, priority=priority)
+        self.goals.append(goal)
+        # keep goals ordered by priority (highest first)
+        self.goals.sort(key=lambda g: g.priority, reverse=True)
+        return goal
+
+    def update_belief(self, statement: str, truth: bool = True) -> Belief:
+        belief = Belief(statement=statement, truth=truth)
+        self.beliefs.append(belief)
+        return belief
+
+    def drop_goal(self, description: str) -> None:
+        self.goals = [g for g in self.goals if g.description != description]
+
+    def complete_goal(self, description: str) -> None:
+        for g in self.goals:
+            if g.description == description:
+                g.satisfied = True
+                break
+
+    def next_goal(self) -> Goal | None:
+        for g in self.goals:
+            if not g.satisfied:
+                return g
+        return None
+
+    def active_goals(self) -> List[Goal]:
+        return [g for g in self.goals if not g.satisfied]
+
+    def list_goals(self) -> List[Goal]:
+        """Return a copy of all goals, regardless of state."""
+        return list(self.goals)
+

--- a/aethermind/reasoning.py
+++ b/aethermind/reasoning.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from typing import Any, Callable
+from .brain import Brain
+from .goals import GoalManager
+from .safeguard import SelfModificationGuard, EmergencyShutdown
+
+class ReasoningLoop:
+    """Simple perceive-interpret-evaluate-act cycle."""
+
+    def __init__(self, brain: Brain, goals: GoalManager,
+                 guard: SelfModificationGuard | None = None,
+                 shutdown: EmergencyShutdown | None = None):
+        self.brain = brain
+        self.goals = goals
+        self.guard = guard or SelfModificationGuard()
+        self.shutdown = shutdown or EmergencyShutdown()
+
+    def perceive(self, data: Any) -> None:
+        """Store raw input in working memory."""
+        self.brain.remember(data)
+
+    def interpret(self, data: Any) -> Any:
+        """Placeholder for semantic interpretation."""
+        return data
+
+    def evaluate(self, interpreted: Any) -> str:
+        """Evaluate the input in light of goals and safety."""
+        self.shutdown.check_phrase(str(interpreted))
+        self.guard.ensure_safe()
+        goal = self.goals.next_goal()
+        if goal:
+            return f"Goal: {goal.description}"
+        return "No goal"
+
+    def decide(self, evaluation: str) -> Callable[[], Any] | None:
+        if "ask" in evaluation.lower():
+            return lambda: "ask"
+        return None
+
+    def act(self, action: Callable[[], Any] | None) -> Any:
+        self.guard.ensure_safe()
+        if action:
+            return action()
+        return None
+
+    def cycle(self, data: Any) -> Any:
+        """Run one reasoning iteration."""
+        self.perceive(data)
+        interpreted = self.interpret(data)
+        evaluation = self.evaluate(interpreted)
+        decision = self.decide(evaluation)
+        return self.act(decision)
+

--- a/aethermind/safeguard.py
+++ b/aethermind/safeguard.py
@@ -1,0 +1,29 @@
+class SelfModificationGuard:
+    """Prevents the agent from altering its own code base."""
+
+    allowed: bool = False
+
+    def ensure_safe(self) -> None:
+        if not self.allowed:
+            # In real deployment this would check file system permissions.
+            raise PermissionError("Self-modification is disallowed")
+
+
+class EmergencyShutdown:
+    """Triggers a safe exit when the special kill phrase is spoken."""
+
+    PHRASE = "pen pinapple apple pen"
+
+    def __init__(self) -> None:
+        self.armed = True
+
+    def disarm(self) -> None:
+        self.armed = False
+
+    def arm(self) -> None:
+        self.armed = True
+
+    def check_phrase(self, speech: str) -> None:
+        if self.armed and self.PHRASE in speech.lower():
+            raise SystemExit("Emergency shutdown command received")
+

--- a/read me.md
+++ b/read me.md
@@ -31,3 +31,15 @@ The AI is restricted from modifying its own controller logic and exposes simple 
 ### Consolidation and Emotional Weighting
 
 Memories move from the short-term cache to episodic memory as the cache fills, and the oldest episodes are archived once episodic storage grows large. Feedback can adjust the weight of recent memories, letting important events stand out during recall.
+
+## Goal and Reasoning System
+
+The second phase introduces a goal manager and reasoning loop. `GoalManager`
+implements a Belief–Desire–Intention style planner with simple priority
+ordering. `ReasoningLoop` follows a Perceive → Interpret → Evaluate → Act
+cycle, using memory to store observations and checking the
+`SelfModificationGuard` before executing actions. This guard enforces the
+immutability constraint so the AI cannot alter its own code. An
+`EmergencyShutdown` module listens for the voice phrase "pen pinapple apple
+pen" and will safely terminate the process if detected, ensuring the agent can
+be halted instantly should it behave unexpectedly.


### PR DESCRIPTION
## Summary
- extend goal system with belief tracking
- add `EmergencyShutdown` kill switch and export via package
- integrate shutdown and safety check into the reasoning loop
- document new shutdown phrase in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847651bc410832784d02634f0f5c92f