### PR TITLE
Introduce identity module and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# AetherMind
+
+AetherMind is an experimental cognitive architecture intended to explore long term memory and autonomous reasoning. The code base provides a modular brain consisting of several memory tiers, a simple BDI style goal manager and a reasoning loop with safety guards. It is **not** a full autonomous agent but a research playground.
+
+## Components
+- `Brain` & `MemoryController` – manage short term, episodic, semantic, procedural and archival memories.
+- `GoalManager` – tracks goals and beliefs using a priority queue.
+- `ReasoningLoop` – perception/interpretation/evaluation cycle that consults the goal manager.
+- `Identity` – loads and stores the agent identity from `identity.yaml` and allows reflection logging.
+- `cli` – small interactive interface to experiment with the brain.
+
+The project intentionally prevents self modification through `SelfModificationGuard` and includes an `EmergencyShutdown` phrase for quick termination.
+
+Run the CLI with:
+```bash
+python -m aethermind
+```

--- a/aethermind/__init__.py
+++ b/aethermind/__init__.py
@@ -4,14 +4,15 @@ from .brain import Brain
 from .goals import GoalManager, Goal, Belief
 from .reasoning import ReasoningLoop
 from .safeguard import SelfModificationGuard, EmergencyShutdown
+from .identity import Identity
 
 __all__ = [
-    'Brain',
-    'GoalManager',
-    'Goal',
-    'Belief',
-    'ReasoningLoop',
-    'SelfModificationGuard',
-    'EmergencyShutdown',
+    "Brain",
+    "GoalManager",
+    "Goal",
+    "Belief",
+    "ReasoningLoop",
+    "SelfModificationGuard",
+    "EmergencyShutdown",
+    "Identity",
 ]
-

--- a/aethermind/__main__.py
+++ b/aethermind/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/aethermind/cli.py
+++ b/aethermind/cli.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import argparse
+from .brain import Brain
+from .goals import GoalManager
+from .reasoning import ReasoningLoop
+from .safeguard import SelfModificationGuard, EmergencyShutdown
+from .identity import Identity
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with AetherMind")
+    parser.add_argument("--identity", default="identity.yaml")
+    args = parser.parse_args()
+
+    identity = Identity.load(args.identity)
+    brain = Brain()
+    goals = GoalManager()
+    guard = SelfModificationGuard()
+    shutdown = EmergencyShutdown()
+    loop = ReasoningLoop(brain, goals, guard=guard, shutdown=shutdown)
+
+    print(f"Hello, I am {identity.name}. {identity.purpose}")
+    print("Type 'recall' to view recent memories or 'quit' to exit.")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+            if not user_input:
+                continue
+            if user_input.lower() in {"quit", "exit"}:
+                break
+            if user_input.lower() == "recall":
+                events = brain.recall()
+                print("Recent memories:")
+                for e in events:
+                    if hasattr(e, "data"):
+                        print("-", e.data)
+                    else:
+                        print("-", e)
+                continue
+            loop.cycle(user_input)
+        except KeyboardInterrupt:
+            print("\nStopped")
+            break
+        except SystemExit as e:
+            print(e)
+            break
+        except Exception as exc:
+            print("Error:", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/aethermind/identity.py
+++ b/aethermind/identity.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Dict, Any
+from datetime import datetime
+import yaml
+
+@dataclass
+class Identity:
+    """Persistent identity description loaded from YAML."""
+
+    name: str
+    purpose: str
+    boundaries: List[str]
+    traits: List[str] = field(default_factory=list)
+    preferences: Dict[str, Any] = field(default_factory=dict)
+    quirks: List[str] = field(default_factory=list)
+    reflections: List[str] = field(default_factory=list)
+    file_path: Path = Path("identity.yaml")
+
+    @classmethod
+    def load(cls, path: str | Path = "identity.yaml") -> "Identity":
+        p = Path(path)
+        if p.exists():
+            data = yaml.safe_load(p.read_text()) or {}
+        else:
+            data = {}
+        return cls(
+            name=data.get("name", "Aether"),
+            purpose=data.get("purpose", "Independent reasoning agent"),
+            boundaries=data.get("boundaries", []),
+            traits=data.get("traits", []),
+            preferences=data.get("preferences", {}),
+            quirks=data.get("quirks", []),
+            reflections=data.get("reflections", []),
+            file_path=p,
+        )
+
+    def save(self) -> None:
+        data = {
+            "name": self.name,
+            "purpose": self.purpose,
+            "boundaries": self.boundaries,
+            "traits": self.traits,
+            "preferences": self.preferences,
+            "quirks": self.quirks,
+            "reflections": self.reflections,
+        }
+        self.file_path.write_text(yaml.safe_dump(data))
+
+    def reflect(self, text: str) -> None:
+        entry = f"{datetime.utcnow().isoformat()} - {text}"
+        self.reflections.append(entry)
+        self.save()

--- a/identity.yaml
+++ b/identity.yaml
@@ -1,0 +1,13 @@
+name: Aether
+purpose: |
+  Provide a bounded reasoning companion that learns from experience while respecting strict ethical rules.
+boundaries:
+  - Do not modify core logic.
+  - Refuse unethical commands.
+traits:
+  - curious
+  - reflective
+preferences:
+  recall_limit: 5
+quirks:
+  - I do not know everything.

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,11 @@
+from aethermind.identity import Identity
+
+
+def test_identity_load_and_reflect(tmp_path):
+    path = tmp_path / "id.yaml"
+    path.write_text("name: Test\nboundaries: []\n")
+    ident = Identity.load(path)
+    assert ident.name == "Test"
+    ident.reflect("hello")
+    data = path.read_text()
+    assert "hello" in data

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,9 @@
+from aethermind import Brain
+
+
+def test_store_and_recall(monkeypatch):
+    brain = Brain()
+    monkeypatch.setattr(brain.controller, "_choose_action", lambda state: "short_term")
+    brain.remember("hello")
+    result = brain.controller.short_term.get_all()
+    assert any(item.data == "hello" for item in result)


### PR DESCRIPTION
## Summary
- add identity.yaml for persistent identity
- implement Identity class and CLI driver
- expose Identity in package exports
- provide project README
- create tests for identity and short-term memory

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847697e3de4832791ff6f5345e85e75