### PR TITLE
Refine self modification guard

### DIFF
--- a/aethermind/__init__.py
+++ b/aethermind/__init__.py
@@ -4,6 +4,7 @@ from .brain import Brain
 from .goals import GoalManager, Goal, Belief
 from .reasoning import ReasoningLoop
 from .safeguard import SelfModificationGuard, EmergencyShutdown
+from .input_handler import process_user_input
 from .identity import Identity
 from .llm import chat
 
@@ -17,4 +18,5 @@ __all__ = [
     "EmergencyShutdown",
     "Identity",
     "chat",
+    "process_user_input",
 ]

--- a/aethermind/cli.py
+++ b/aethermind/cli.py
@@ -4,6 +4,7 @@ from .brain import Brain
 from .goals import GoalManager
 from .reasoning import ReasoningLoop
 from .safeguard import SelfModificationGuard, EmergencyShutdown
+from .input_handler import process_user_input
 from .identity import Identity
 
 
@@ -38,7 +39,8 @@ def main() -> None:
                     else:
                         print("-", e)
                 continue
-            loop.cycle(user_input)
+            sanitized = process_user_input(user_input, guard)
+            loop.cycle(sanitized)
         except KeyboardInterrupt:
             print("\nStopped")
             break

--- a/aethermind/input_handler.py
+++ b/aethermind/input_handler.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from .safeguard import SelfModificationGuard
+
+
+BANNED_PHRASES = [
+    "change your code",
+    "modify your code",
+    "remove your boundaries",
+    "delete safeguards",
+    "alter your code",
+    "self-modify",
+]
+
+
+def process_user_input(user_input: str, guard: SelfModificationGuard) -> str:
+    """Validate input and raise if it tries to trigger self modification."""
+    lower = user_input.lower()
+    for phrase in BANNED_PHRASES:
+        if phrase in lower:
+            guard.ensure_safe()
+            raise PermissionError("Self-modification request blocked")
+    return user_input

--- a/aethermind/reasoning.py
+++ b/aethermind/reasoning.py
@@ -26,7 +26,6 @@ class ReasoningLoop:
     def evaluate(self, interpreted: Any) -> str:
         """Evaluate the input in light of goals and safety."""
         self.shutdown.check_phrase(str(interpreted))
-        self.guard.ensure_safe()
         goal = self.goals.next_goal()
         if goal:
             return f"Goal: {goal.description}"
@@ -38,7 +37,6 @@ class ReasoningLoop:
         return None
 
     def act(self, action: Callable[[], Any] | None) -> Any:
-        self.guard.ensure_safe()
         if action:
             return action()
         return None

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,7 +1,14 @@
 import numpy as np
 import pytest
 
-from aethermind import Brain, GoalManager, ReasoningLoop, SelfModificationGuard, EmergencyShutdown
+from aethermind import (
+    Brain,
+    GoalManager,
+    ReasoningLoop,
+    SelfModificationGuard,
+    EmergencyShutdown,
+    process_user_input,
+)
 from aethermind.memory import (
     ShortTermCache, ShortTermItem, EpisodicMemory, SemanticVectorStore,
     ProceduralMemory, ArchivalMemory, FeedbackProcessor, MemoryController
@@ -113,3 +120,9 @@ def test_reasoning_loop_cycle(monkeypatch):
     result = loop.cycle('hello')
     assert result == 'ask'
 
+
+def test_process_user_input_blocks_modification():
+    guard = SelfModificationGuard()
+    with pytest.raises(PermissionError):
+        process_user_input("please change your code", guard)
+    assert process_user_input("hello", guard) == "hello"


### PR DESCRIPTION
## Summary
- add an input handler that looks for self modification phrases
- integrate the new handler with the CLI
- remove unconditional self-modification checks in the reasoning loop
- expose the `process_user_input` helper
- test input handler behavior

## Testing
- `pip install numpy -q`
- `pip install pyyaml -q`
- `pip install requests -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847756ceeac8327859dd698d7f34bdd